### PR TITLE
[35기 nhouse 조예슬] 카카오 로그인 api 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,7 +400,6 @@ zsdoc/data
 
 # End of https://www.toptal.com/developers/gitignore/api/pycharm,python,visualstudiocode,vim,macos,linux,zsh
 
-
 my_settings.py
 CSV
 

--- a/nhouse/settings.py
+++ b/nhouse/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib     import Path
-from my_settings import DATABASES, SECRET_KEY
+from my_settings import DATABASES, SECRET_KEY, KAKAO_REST_API_KEY, ALGORITHM, REDIRECT_URI
 
 import pymysql
 

--- a/nhouse/urls.py
+++ b/nhouse/urls.py
@@ -1,20 +1,6 @@
-"""nhouse URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/4.0/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.urls import path,include
 
 urlpatterns = [
     path('products', include('products.urls')),
+    path('users', include('users.urls')),
 ]

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,351 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from unittest.mock import patch, MagicMock
 
-# Create your tests here.
+from users.models import User, Follow 
+
+class LoginViewTestSetting(TestCase):
+    def execute(self, mocked_request, MockedAccessToken, MockedUserData, authorization_code, status_code, response_message):
+        client = Client()
+        mock = MagicMock()
+        mock.side_effect = [MockedAccessToken, MockedUserData]
+        mocked_request.post = mock
+        
+        header = {'HTTP_AUTHORIZATION' : authorization_code}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, status_code)
+        self.assertEqual(response.json().get('message'), response_message)
+
+class LoginViewTest(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id = 1,
+            kakao_id = 12345,
+            email = 'snoopy@gmail.com',
+            nickname = 'Snoopy',
+            profile_image = 'http://snoopy.com'
+        )
+
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch('users.views.requests')
+    def test_success_login_with_same_nickname_email_profile_image(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 12345, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'snoopy', 
+                            'thumbnail_image_url': 'http://snoopy.com', 
+                            'profile_image_url': 'http://snoopy.com'
+                            }, 
+                        'email': 'snoopy@gmail.com'
+                        }
+                    }
+
+        authorization_code = '12341234'
+        status_code = 200
+        response_message = 'LOGIN_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+    
+    @patch('users.views.requests')
+    def test_success_login_without_nickname_email_profile_image(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 12345, 
+                    'kakao_account': {
+                        'profile_nickname_needs_agreement': False, 
+                        'profile_image_needs_agreement': False, 
+                        'has_email': True, 
+                        'email_needs_agreement': True
+                        }
+                    }   
+        authorization_code = '12341234'
+        status_code = 200
+        response_message = 'LOGIN_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_login_with_different_nickname(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 12345, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'snoopy12', 
+                            'profile_image_url': 'http://snoopy.com'
+                            }, 
+                        'email': 'snoopy@gmail.com'
+                        }
+                    }
+
+        authorization_code = '12341234'
+        status_code = 200
+        response_message = 'LOGIN_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_login_with_different_profile_image(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 12345, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'snoopy', 
+                            'profile_image_url': 'http://snoopy111.com'
+                            }, 
+                        'email': 'snoopy@gmail.com'
+                        }
+                    }
+
+        authorization_code = '12341234'
+        status_code = 200
+        response_message = 'LOGIN_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_login_with_different_email(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 12345, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'snoopy', 
+                            'profile_image_url': 'http://snoopy.com'
+                            }, 
+                        'email': 'snoopy123@gmail.com'
+                        }
+                    }
+
+        authorization_code = '12341234'
+        status_code = 200
+        response_message = 'LOGIN_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_signup_with_nickname_email_profile_image(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 678910, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'garfield', 
+                            'profile_image_url': 'http://garfield.com'
+                            }, 
+                        'email': 'garfield@gmail.com'
+                        }
+                    }  
+        authorization_code = '12341234'
+        status_code = 201
+        response_message = 'SIGNUP_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_signup_without_nickname_email_profile_image(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 678910, 
+                    'kakao_account': {
+                        'profile_nickname_needs_agreement': False, 
+                        'profile_image_needs_agreement': False, 
+                        'has_email': True, 
+                        'email_needs_agreement': True
+                        }
+                    }   
+        authorization_code = '12341234'
+        status_code = 201
+        response_message = 'SIGNUP_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_signup_without_nickname(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 678910, 
+                    'kakao_account': {
+                        'profile': {
+                            'profile_image_url': 'http://garfield.com'
+                            }, 
+                        'email': 'garfield@gmail.com'
+                        }
+                    } 
+        authorization_code = '12341234'
+        status_code = 201
+        response_message = 'SIGNUP_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_signup_without_profile_image(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 678910, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'garfield'
+                            }, 
+                        'email': 'garfield@gmail.com'
+                        }
+                    } 
+        authorization_code = '12341234'
+        status_code = 201
+        response_message = 'SIGNUP_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_success_signup_without_email(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 678910, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'garfield',
+                            'profile_image_url': 'http://garfield.com'
+                            }, 
+                        }
+                    } 
+        authorization_code = '12341234'
+        status_code = 201
+        response_message = 'SIGNUP_SUCCESS'
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+    
+    @patch('users.views.requests')
+    def test_fail_invalid_authorization_code(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 12345, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'snoopy', 
+                            'profile_image_url': 'http://snoopy.com'
+                            }, 
+                        'email': 'snoopy@gmail.com'
+                        }
+                    }
+
+        authorization_code = ''
+        status_code = 401
+        response_message = "INVALID_AUTHORIZATION_CODE"
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+        
+    @patch('users.views.requests')
+    def test_fail_invalid_access_token(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : ''}
+
+        class MockedUserData:
+            def json(self):
+                return {
+                    'id': 12345, 
+                    'kakao_account': {
+                        'profile': {
+                            'nickname': 'snoopy', 
+                            'thumbnail_image_url': 'http://snoopy.com', 
+                            'profile_image_url': 'http://snoopy.com'
+                            }, 
+                        'email': 'snoopy@gmail.com'
+                        }
+                    }
+
+        authorization_code = '12341234'
+        status_code = 401
+        response_message = "INVALID_ACCESS_TOKEN"
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+
+    @patch('users.views.requests')
+    def test_fail_invalid_kakao_id(self, mocked_request):
+        class MockedAccessToken:
+            def json(self):
+                return {'access_token' : '1234'}
+
+        class MockedUserData:
+            def json(self):
+                return {}
+
+        authorization_code = '12341234'
+        status_code = 401
+        response_message = "INVALID_KAKAO_ID"
+
+        test = LoginViewTestSetting()
+        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+    

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from users.views import LoginView
+
+urlpatterns = [
+    path('/login', LoginView.as_view()),
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,0 +1,73 @@
+import jwt
+import requests
+
+from django.http      import JsonResponse
+from django.views     import View
+from django.conf      import settings
+
+from users.models     import User
+
+class LoginView(View):
+    def get(self, request):
+        try:
+            code = request.META.get('HTTP_AUTHORIZATION')
+            
+            if not code:
+                return JsonResponse({"message" : "INVALID_AUTHORIZATION_CODE"}, status=401)
+
+            data = {
+                'grant_type' : 'authorization_code',
+                'client_id' : settings.KAKAO_REST_API_KEY,
+                'redirect_uri' : settings.REDIRECT_URI,
+                'code' : code
+            }
+            token_response = requests.post("https://kauth.kakao.com/oauth/token", data=data).json()
+            access_token   = token_response.get('access_token')
+          
+            if not access_token:
+                return JsonResponse({"message" : "INVALID_ACCESS_TOKEN"}, status=401)
+
+            headers = {
+                'Authorization': f'Bearer {access_token}'
+            }
+            user_data_response = requests.post("https://kapi.kakao.com/v2/user/me", headers=headers).json()
+            kakao_id = user_data_response.get('id')
+            
+            if not kakao_id:
+                return JsonResponse({"message" : "INVALID_KAKAO_ID"}, status=401)
+
+            kakao_account = user_data_response['kakao_account']
+            email         = kakao_account.get('email')
+            nickname      = None 
+            profile_image = None
+            profile       = kakao_account.get('profile')
+
+            if profile:
+                nickname      = profile.get('nickname')
+                profile_image = profile.get('profile_image_url')
+                
+            user, is_created = User.objects.get_or_create(
+                kakao_id = kakao_id,
+                defaults = {
+                    "email"        : email,
+                    "nickname"     : nickname,
+                    "profile_image": profile_image
+                }
+            )
+            nhouse_token = jwt.encode({"user_id" : user.id}, settings.SECRET_KEY, settings.ALGORITHM)
+
+            if not is_created:
+                if not user.email == email:
+                    user.email = email 
+                    user.save()
+                if not user.profile_image == profile_image:
+                    user.profile_image = profile_image
+                    user.save()
+                if not user.nickname == nickname:
+                    user.nickname = nickname
+                return JsonResponse({"message" : "LOGIN_SUCCESS", "access_token" : nhouse_token}, status=200)
+
+            return JsonResponse({"message" : "SIGNUP_SUCCESS", "access_token" : nhouse_token}, status=201)  
+
+        except KeyError:
+            return JsonResponse({"message":"KEY_ERROR"}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 카카오 로그인 api로 내일의 집 로그인/회원가입 구현하기
- 회원가입 성공 시 "SIGNUP_SUCCESS" 메시지와 201 코드 반환
- 로그인 성공 시 "LOGIN_SUCCESS" 메시지와 200 코드 반환
- 인가 코드가 유효하지 않은 경우 "INVALID_AUTHORIZATION_CODE" 메시지와 401 코드 반환
- 액세스 코드가 유효하지 않은 경우 "INVALID_ACCESS_TOKEN" 메시지와 401 코드 반환
- 카카오 id가 유효하지 않은 경우 "INVALID_KAKAO_ID" 메시지와 401 코드 반환
- 키 에러가 나는 경우 "KEY_ERROR" 메시지와 400 코드 반환
- unit test 진행

<br />

## :: 구현 사항 설명 
1. 프론트에서 보내주는 인가 코드를 전달받음
2. 토큰을 발급하는 카카오 REST API에 django requests로 요청 보내고 카카오 토큰 응답받기
3. 유저 정보를 응답하는 카카오 REST API에 django requsts로 요청 보내고 유저 정보 응답받기
4. 유저 정보를 응답받으면 유저의 카카오 아이디가 DB에 있는지 확인
5. 유저의 카카오 아이디가 DB에 있으면 "LOGIN_SUCCESS" 메시지와 jwt 반환 
6. 유저의 카카오 아이디가 DB에 없으면 DB에 유저 정보 저장 후 "SIGNUP_SUCCESS" 메시지와 jwt 반환
7. unit test 코드 작성해서 테스트 자동화
 
<br />

## :: 성장 포인트 
- 공식 문서를 읽어보고 REST API를 사용해보았습니다.
   + 카카오 API의 인가 코드, 토큰, 서비스에서 발급하는 jwt 토큰의 역할과 차이점에 대해 알게 되었습니다.
      - 인가 코드는 내일의 집이 카카오의 유저 정보에 접근해도 된다는 증거입니다.
      - 카카오 토큰은 유저가 카카오에 로그인했다는 증거입니다.
      - 내일의 집에서 발급하는 jwt는 유저가 내일의 집에 로그인했다는 증거입니다.
  
    + 낯선 기술을 사용할 때 효율적으로 공부하는 방식에 대해 생각해보았습니다.
      - 우선 공식 문서를 읽습니다.
      - 모르는 단어나 이해가 가지 않는 부분은 리서치를 해서 제대로 이해합니다.
      - 그런 다음 공식 문서를 누군가에게 설명한다고 생각하고 내 언어로 정리해봅니다.
      - 이제 공부한 기술을 내 프로젝트의 어느 부분에 어떻게 적용할 지 글로 간단하게 정리해봅니다.
      - 구체적인 적용 방법을 모르겠으면 리서치를 합니다.
      - 코드를 작성합니다. 

- 인증, 인가의 개념에 대해 더 잘 이해하게 되었습니다.
   + 인증은 유저가 우리 서비스에 등록된 유저인지 확인하는 것입니다.
   + 인가는 유저가 어딘가에 접근하려고 할 때 권한이 있는지 확인하는 것입니다.

- django의 requests 모듈을 사용해보았습니다.
   + requests 모듈을 사용하면 django에서 외부 REST API를 호출할 수 있음을 알게 되었습니다.
   + django에서 API를 호출할 때 요청 헤더와 바디에 어떻게 정보를 담아 보낼 수 있는지 배웠습니다.

- 테스트 코드를 작성해서 unit test를 진행해보았습니다.
   + magic mock을 사용해서 외부 api 호출 없이 테스트를 진행하도록 설정했습니다.
   + 테스트 가능한 경우의 수를 떠올리고 정리해서 코드로 풀어보았습니다.
   + 테스트 자동화의 중요성을 느꼈습니다.   

<br />

## :: 기타 질문 및 특이 사항
- 코멘트로 달아두었습니다.