### PR TITLE
[35기 nhouse 조예슬] 포스트 리스트 api 

### DIFF
--- a/nhouse/urls.py
+++ b/nhouse/urls.py
@@ -4,4 +4,5 @@ urlpatterns = [
     path('products', include('products.urls')),
     path('users', include('users.urls')),
     path('search', include('search.urls')),
+    path('posts', include('posts.urls'))
 ]

--- a/posts/tests.py
+++ b/posts/tests.py
@@ -1,3 +1,113 @@
-from django.test import TestCase
+from django.test  import TestCase, Client
 
-# Create your tests here.
+from posts.models import Post, Photo
+from users.models import User
+
+class PostListViewTest(TestCase):
+    def setUp(self):
+        User.objects.bulk_create([
+            User(id=1, kakao_id = 1234)
+        ])
+
+        Post.objects.bulk_create([
+            Post(
+                id          = 1,
+                title       = '트렌디한 인테리어 시공으로 살림이 즐거워지는 집',
+                content     = '안녕하세요.',
+                cover_image = 'https://images.unsplash.com/photo-1513694203232-719a280e022f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1738&q=80',
+                living_type = '원룸',
+                room_size   = '10평 미만',
+                family_type = '싱글라이프',
+                work_type   = '홈스타일링',
+                worker_type = '셀프',
+                user_id     = 1 
+            ),
+            Post(
+                id          = 2,
+                title       = '트렌디한 인테리어 시공으로 살림이 즐거워지는 집',
+                content     = '안녕하세요.',
+                cover_image = 'https://images.unsplash.com/photo-1522771739844-6a9f6d5f14af?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1171&q=80',
+                living_type = '오피스텔',
+                room_size   = '10평대',
+                family_type = '부부',
+                work_type   = '리모델링',
+                worker_type = '반셀프',
+                user_id     = 1 
+            )
+        ])
+
+        Photo.objects.bulk_create([
+            Photo(
+                id          = 1,
+                description = '오늘, 우리집. 얼마만에 푹 쉬는 주말인지.',
+                url         = 'https://images.unsplash.com/photo-1513694203232-719a280e022f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1738&q=80',
+                post_id     = 1
+            ),
+            Photo(
+                id          = 2,
+                description = '다채로운 꽃이 한가득 새겨진 쿠션커버',
+                url         = 'https://images.unsplash.com/photo-1522771739844-6a9f6d5f14af?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1171&q=80',
+                post_id     = 1
+            ),
+            Photo(
+                id          = 3,
+                description = '흐린 날, 간접 조명은 더욱 빛을 발한다.',
+                url         = 'https://images.unsplash.com/photo-1522771739844-6a9f6d5f14af?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1171&q=80',
+                post_id     = 2
+            ),
+            Photo(
+                id          = 4,
+                description = '너무 귀여운 아보카도 베딩',
+                url         = 'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=958&q=80',
+                post_id     = 2
+            )
+        ])
+
+    def tearDown(self):
+        Post.objects.all().delete()
+        User.objects.all().delete()
+        Photo.objects.all().delete()
+
+    def test_success_filter_all(self):
+        client = Client()
+        response = client.get('/posts/list?living-type=원룸&room-size=10평 미만&family-type=싱글라이프&work-type=홈스타일링&worker-type=셀프')
+    
+        self.assertEqual(response.json(),{
+            "total": {
+                "total_items": 1,
+                "total_pages": 1,
+                "current_page": 1,
+                "limit": 10
+            },
+            "posts": [
+                {
+                    "id": 1,
+                    "cover_image": "https://images.unsplash.com/photo-1513694203232-719a280e022f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1738&q=80",
+                    "first_description": "오늘, 우리집. 얼마만에 푹 쉬는 주말인지.",
+                    "user": {
+                        "id": 1,
+                        "nickname": None
+                    }
+                }
+            ]
+        })
+
+    def test_success_no_matching_queries(self):
+        client = Client()
+        response = client.get('/posts/list?living-type=오피스텔&room-size=10평 미만&family-type=싱글라이프&work-type=홈스타일링&worker-type=셀프')
+        self.assertEqual(response.json(), {
+            "total": {
+                "total_items": 0,
+                "total_pages": 1,
+                "current_page": 1,
+                "limit": 10
+            },
+            "posts": []
+        })
+
+    def test_fail_invalid_page(self):
+        client = Client()
+        response = client.get('/posts/list?offset=100')
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {'result': 'INVALID_PAGE'})

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from posts.views import PostListView
+
+urlpatterns = [
+    path('/list', PostListView.as_view()),
+]

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,3 +1,61 @@
-from django.shortcuts import render
+from django.http           import JsonResponse
+from django.views          import View
+from django.db.models      import Q
+from django.core.paginator import Paginator
 
-# Create your views here.
+from posts.models          import Post
+
+class PostListView(View):
+    def get(self, request):
+        living_type = request.GET.get('living-type')
+        room_size   = request.GET.get('room-size')
+        family_type = request.GET.get('family-type')
+        work_type   = request.GET.get('work-type')
+        worker_type = request.GET.get('worker-type')
+        limit       = int(request.GET.get("limit", 10))
+        offset      = int(request.GET.get("offset", 1))
+
+        queries = Q()
+
+        if living_type:
+            queries &= Q(living_type=living_type)
+        
+        if room_size:
+            queries &= Q(room_size=room_size)
+
+        if family_type:
+            queries &= Q(family_type=family_type)
+
+        if work_type:
+            queries &= Q(work_type=work_type)
+
+        if worker_type:
+            queries &= Q(worker_type=worker_type)
+
+        posts = Post.objects.filter(queries).order_by('-created_at').select_related('user').prefetch_related('photo_set')
+
+        p = Paginator(posts, limit)
+        pages_count = p.num_pages
+
+        if offset < 1 or offset > pages_count:
+            return JsonResponse({'result': 'INVALID_PAGE'}, status=404)
+
+        total = {
+            'total_items' : posts.count(),
+            'total_pages' : pages_count,
+            'current_page': offset,
+            'limit'       : limit
+        }
+        
+        page_items = p.page(offset) 
+        posts = [{
+            'id'               : page_item.id,
+            'cover_image'      : page_item.cover_image,
+            'first_description': page_item.photo_set.all()[0].description,
+            'user' : {
+                'id' : page_item.user.id,
+                'nickname' : page_item.user.nickname
+            }
+        } for page_item in page_items]
+
+        return JsonResponse({'total' : total, 'posts': posts}, status=200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 주거 형태, 평수, 가족형태, 작업 분야, 작업자에 따라 포스트를 필터링
- 페이지네이션 구현
- 요청 성공 시 페이지 정보, 상품 목록과 코드 200 반환
- 존재하지 않는 카테고리나 페이지 요청 시 404 에러 반환

<br />

## :: 구현 사항 설명 
1. 엔드포인트 : /posts/list
2. 쿼리 파라미터에 필터링 항목을 입력하면 주거 형태, 평수, 가족형태, 작업 분야, 작업자에 따라 포스트를 필터링해서 보여줍니다.
3. 디폴트로 10개씩 포스트를 끊어 최신 포스트 순으로 보여줍니다.

<br />

## :: 성장 포인트 
- 정참조와 역참조 관계에 대해 더 잘 이해하게 되었습니다.
    + Post 모델은 User 모델을 정참조합니다. 
    + Post 모델은 Photo 모델을 역참조합니다. 
    + 역참조 시에는 related_name을 사용하지 않는 경우 _set 매니저를 사용합니다.  
 
- django ORM을 최적화했습니다.
   + select_related를 사용하여 DB에서 posts 테이블과 users 테이블을 inner join해서 한 번에 가져와 캐싱하도록 했습니다.
  + prefetch_related를 사용하여 DB에서 photos 테이블을 가져와 inner join해서 가져온 posts 테이블과 users 테이블과 연결해서 캐싱하도록 했습니다.
  + 로그를 찍어보며 왜 django ORM 최적화가 필요한지 이해했습니다.

<br />

## :: 기타 질문 및 특이 사항
- 'photos' 테이블을 prefetch_related('photo')를 사용해서 캐싱하더라도 first()를 사용하면 캐시를 사용하지 않고 DB를 호출하는 것을 확인했습니다. 여기서 Prefetch 오브젝트를 사용해서 first()를 사용할 수 있는 방법이 있을까요? 
