### PR TITLE
[35기 nhouse 조예슬] 로그인 데코레이터

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,28 @@
+import json
+
+import jwt
+
+from django.http  import JsonResponse
+from users.models import User
+from django.conf  import settings
+
+def login_decorator(func):
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            access_token = request.headers.get('Authorization')
+            payload      = jwt.decode(access_token, settings.SECRET_KEY, settings.ALGORITHM)
+            user_id      = payload['user_id']
+            request.user = User.objects.get(id = user_id)
+
+            return func(self, request, *args, **kwargs)
+
+        except jwt.exceptions.DecodeError:
+            return JsonResponse({ 'message' : 'INVALID_TOKEN' }, status = 400)
+
+        except KeyError:
+            return JsonResponse({ 'message' : 'KEY_ERROR' }, status = 400)
+
+        except User.DoesNotExist:
+            return JsonResponse({'message' : 'INVALID_USER'}, status = 401)
+
+    return wrapper


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- jwt 토큰을 이용한 로그인 데코레이터 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 유저 인가가 필요한 api에 사용합니다.
2. 프론트에서 요청 헤더에 유저의 jwt 토큰을 넣어 보내면, 
   - 해당 데코레이터에서 토큰을 디코딩합니다.
   - 토큰의 페이로드에 들어있는 유저의 아이디가 db에 있으면 원래 실행해야 할 함수를 실행합니다.
   - 등록되지 않은 유저라면 'INVALID_USER' 메시지와 401 코드를 반환합니다.
   - 토큰 디코딩 시 에러가 나면 'INVALID_TOKEN' 메시지와 400 코드를 반환합니다.
   - 키 에러가 나면 'KEY_ERROR' 메시지와 400 코드를 반환합니다.

<br />

## :: 성장 포인트 
- 인가 과정에 대해 복습할 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 데코레이터는 어떻게 유닛 테스트를 해야 할 지 모르겠습니다. 데코레이터가 감쌀 함수를 mock으로 만들어서 진행해야 하나요? 
