### PR TITLE
[35기 nhouse 조예슬] 카카오 로그인 api 리팩토링

### DIFF
--- a/nhouse/settings.py
+++ b/nhouse/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib     import Path
-from my_settings import DATABASES, SECRET_KEY, KAKAO_REST_API_KEY, ALGORITHM, REDIRECT_URI
+from my_settings import DATABASES, SECRET_KEY, ALGORITHM, KAKAO_CONFIG 
 
 import pymysql
 

--- a/products/views.py
+++ b/products/views.py
@@ -20,7 +20,6 @@ class FirstCategoryView(View):
 
 
 class ProductDetailView(View):
-    @query_debugger
     def get(self, request, product_id):
         products = Product.objects.filter(id=product_id)\
             .select_related("second_category__first_category","brand")\

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,20 +1,7 @@
 from django.test import TestCase, Client
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from users.models import User, Follow 
-
-class LoginViewTestSetting(TestCase):
-    def execute(self, mocked_request, MockedAccessToken, MockedUserData, authorization_code, status_code, response_message):
-        client = Client()
-        mock = MagicMock()
-        mock.side_effect = [MockedAccessToken, MockedUserData]
-        mocked_request.post = mock
-        
-        header = {'HTTP_AUTHORIZATION' : authorization_code}
-        response = client.get('/users/login', content_type='applications/json', **header)
-        
-        self.assertEqual(response.status_code, status_code)
-        self.assertEqual(response.json().get('message'), response_message)
 
 class LoginViewTest(TestCase):
     def setUp(self):
@@ -28,16 +15,14 @@ class LoginViewTest(TestCase):
 
     def tearDown(self):
         User.objects.all().delete()
+    
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_login_with_same_nickname_email_profile_image(self, mocked_access_token, mocked_user_data):
+        client = Client()
 
-    @patch('users.views.requests')
-    def test_success_login_with_same_nickname_email_profile_image(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
                     'id': 12345, 
                     'kakao_account': {
                         'profile': {
@@ -49,303 +34,277 @@ class LoginViewTest(TestCase):
                         }
                     }
 
-        authorization_code = '12341234'
-        status_code = 200
-        response_message = 'LOGIN_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-    
-    @patch('users.views.requests')
-    def test_success_login_without_nickname_email_profile_image(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 12345, 
-                    'kakao_account': {
-                        'profile_nickname_needs_agreement': False, 
-                        'profile_image_needs_agreement': False, 
-                        'has_email': True, 
-                        'email_needs_agreement': True
-                        }
-                    }   
-        authorization_code = '12341234'
-        status_code = 200
-        response_message = 'LOGIN_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_login_with_different_nickname(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 12345, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'snoopy12', 
-                            'profile_image_url': 'http://snoopy.com'
-                            }, 
-                        'email': 'snoopy@gmail.com'
-                        }
-                    }
-
-        authorization_code = '12341234'
-        status_code = 200
-        response_message = 'LOGIN_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_login_with_different_profile_image(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 12345, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'snoopy', 
-                            'profile_image_url': 'http://snoopy111.com'
-                            }, 
-                        'email': 'snoopy@gmail.com'
-                        }
-                    }
-
-        authorization_code = '12341234'
-        status_code = 200
-        response_message = 'LOGIN_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_login_with_different_email(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 12345, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'snoopy', 
-                            'profile_image_url': 'http://snoopy.com'
-                            }, 
-                        'email': 'snoopy123@gmail.com'
-                        }
-                    }
-
-        authorization_code = '12341234'
-        status_code = 200
-        response_message = 'LOGIN_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_signup_with_nickname_email_profile_image(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 678910, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'garfield', 
-                            'profile_image_url': 'http://garfield.com'
-                            }, 
-                        'email': 'garfield@gmail.com'
-                        }
-                    }  
-        authorization_code = '12341234'
-        status_code = 201
-        response_message = 'SIGNUP_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_signup_without_nickname_email_profile_image(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 678910, 
-                    'kakao_account': {
-                        'profile_nickname_needs_agreement': False, 
-                        'profile_image_needs_agreement': False, 
-                        'has_email': True, 
-                        'email_needs_agreement': True
-                        }
-                    }   
-        authorization_code = '12341234'
-        status_code = 201
-        response_message = 'SIGNUP_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_signup_without_nickname(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 678910, 
-                    'kakao_account': {
-                        'profile': {
-                            'profile_image_url': 'http://garfield.com'
-                            }, 
-                        'email': 'garfield@gmail.com'
-                        }
-                    } 
-        authorization_code = '12341234'
-        status_code = 201
-        response_message = 'SIGNUP_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_signup_without_profile_image(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 678910, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'garfield'
-                            }, 
-                        'email': 'garfield@gmail.com'
-                        }
-                    } 
-        authorization_code = '12341234'
-        status_code = 201
-        response_message = 'SIGNUP_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-
-    @patch('users.views.requests')
-    def test_success_signup_without_email(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 678910, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'garfield',
-                            'profile_image_url': 'http://garfield.com'
-                            }, 
-                        }
-                    } 
-        authorization_code = '12341234'
-        status_code = 201
-        response_message = 'SIGNUP_SUCCESS'
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
-    
-    @patch('users.views.requests')
-    def test_fail_invalid_authorization_code(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
-
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 12345, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'snoopy', 
-                            'profile_image_url': 'http://snoopy.com'
-                            }, 
-                        'email': 'snoopy@gmail.com'
-                        }
-                    }
-
-        authorization_code = ''
-        status_code = 401
-        response_message = "INVALID_AUTHORIZATION_CODE"
-
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
         
-    @patch('users.views.requests')
-    def test_fail_invalid_access_token(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : ''}
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get('message'), 'LOGIN_SUCCESS')
 
-        class MockedUserData:
-            def json(self):
-                return {
-                    'id': 12345, 
-                    'kakao_account': {
-                        'profile': {
-                            'nickname': 'snoopy', 
-                            'thumbnail_image_url': 'http://snoopy.com', 
-                            'profile_image_url': 'http://snoopy.com'
-                            }, 
-                        'email': 'snoopy@gmail.com'
-                        }
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_login_without_nickname_email_profile_image(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 12345, 
+            'kakao_account': {
+                'profile_nickname_needs_agreement': False, 
+                'profile_image_needs_agreement': False, 
+                'has_email': True, 
+                'email_needs_agreement': True
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get('message'), 'LOGIN_SUCCESS') 
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_login_with_different_nickname(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 12345, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'snoopy12', 
+                    'profile_image_url': 'http://snoopy.com'
+                    }, 
+                'email': 'snoopy@gmail.com'
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get('message'), 'LOGIN_SUCCESS') 
+        self.assertEqual(User.objects.get(id=1).nickname, 'snoopy12')
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_login_with_different_profile_image(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 12345, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'snoopy', 
+                    'profile_image_url': 'http://snoopy12.com'
+                    }, 
+                'email': 'snoopy@gmail.com'
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get('message'), 'LOGIN_SUCCESS') 
+        self.assertEqual(User.objects.get(id=1).profile_image, 'http://snoopy12.com')
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_login_with_different_email(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 12345, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'snoopy', 
+                    'profile_image_url': 'http://snoopy.com'
+                    }, 
+                'email': 'snoopy12@gmail.com'
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get('message'), 'LOGIN_SUCCESS') 
+        self.assertEqual(User.objects.get(id=1).email, 'snoopy12@gmail.com') 
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_signup_with_nickname_email_profile_image(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 678910, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'garfield', 
+                    'profile_image_url': 'http://garfield.com'
+                    }, 
+                'email': 'garfield@gmail.com'
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json().get('message'), 'SIGNUP_SUCCESS') 
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_signup_without_nickname_email_profile_image(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 678910, 
+            'kakao_account': {
+                'profile_nickname_needs_agreement': False, 
+                'profile_image_needs_agreement': False, 
+                'has_email': True, 
+                'email_needs_agreement': True
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json().get('message'), 'SIGNUP_SUCCESS') 
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_signup_without_nickname(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 678910, 
+            'kakao_account': {
+                'profile': {
+                    'profile_image_url': 'http://garfield.com'
+                    }, 
+                'email': 'garfield@gmail.com'
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json().get('message'), 'SIGNUP_SUCCESS')  
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_signup_without_profile_image(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 678910, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'garfield'
+                    }, 
+                'email': 'garfield@gmail.com'
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json().get('message'), 'SIGNUP_SUCCESS') 
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_success_signup_without_email(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 678910, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'garfield', 
+                    'profile_image_url': 'http://garfield.com'
                     }
+                }
+            }
 
-        authorization_code = '12341234'
-        status_code = 401
-        response_message = "INVALID_ACCESS_TOKEN"
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json().get('message'), 'SIGNUP_SUCCESS')  
 
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_fail_invalid_authorization_code(self, mocked_access_token, mocked_user_data):
+        client = Client()
 
-    @patch('users.views.requests')
-    def test_fail_invalid_kakao_id(self, mocked_request):
-        class MockedAccessToken:
-            def json(self):
-                return {'access_token' : '1234'}
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {
+            'id': 678910, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'garfield', 
+                    'profile_image_url': 'http://garfield.com'
+                    }, 
+                'email': 'garfield@gmail.com'
+                }
+            }
 
-        class MockedUserData:
-            def json(self):
-                return {}
+        header = {'HTTP_AUTHORIZATION' : ''}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json().get('message'), "INVALID_AUTHORIZATION_CODE") 
 
-        authorization_code = '12341234'
-        status_code = 401
-        response_message = "INVALID_KAKAO_ID"
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_fail_invalid_access_token(self, mocked_access_token, mocked_user_data):
+        client = Client()
 
-        test = LoginViewTestSetting()
-        test.execute(mocked_request, MockedAccessToken(), MockedUserData(), authorization_code, status_code, response_message)
+        mocked_access_token.return_value = ''
+        mocked_user_data.return_value = {
+            'id': 678910, 
+            'kakao_account': {
+                'profile': {
+                    'nickname': 'garfield', 
+                    'profile_image_url': 'http://garfield.com'
+                    }, 
+                'email': 'garfield@gmail.com'
+                }
+            }
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json().get('message'), "INVALID_ACCESS_TOKEN") 
+
+    @patch('users.views.KakaoAPI.get_kakao_user_data')
+    @patch('users.views.KakaoAPI.get_access_token')
+    def test_fail_invalid_kakao_id(self, mocked_access_token, mocked_user_data):
+        client = Client()
+
+        mocked_access_token.return_value = '1234'
+        mocked_user_data.return_value = {}
+
+        header = {'HTTP_AUTHORIZATION' : '12341234'}
+        response = client.get('/users/login', content_type='applications/json', **header)
+        
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json().get('message'), 'INVALID_KAKAO_ID') 
+
+
+
     

--- a/users/views.py
+++ b/users/views.py
@@ -7,36 +7,49 @@ from django.conf      import settings
 
 from users.models     import User
 
+class KakaoAPI:
+    def __init__(self, config):
+        self.config = config 
+    
+    def get_access_token(self, authorization_code):
+        data = {
+                'grant_type' : 'authorization_code',
+                'client_id' : self.KAKAO_CONFIG['api_key'],
+                'redirect_uri' : self.KAKAO_CONFIG['redirect_uri'],
+                'code' : authorization_code
+            }
+        token_response = requests.post("https://kauth.kakao.com/oauth/token", data=data).json()
+        access_token   = token_response.get('access_token')
+          
+        return access_token
+
+    def get_kakao_user_data(self, access_token):
+        headers = {
+                'Authorization': f'Bearer {access_token}'
+            }
+        user_data = requests.post("https://kapi.kakao.com/v2/user/me", headers=headers).json()
+        return user_data
+
 class LoginView(View):
     def get(self, request):
         try:
             code = request.META.get('HTTP_AUTHORIZATION')
-            
             if not code:
                 return JsonResponse({"message" : "INVALID_AUTHORIZATION_CODE"}, status=401)
-
-            data = {
-                'grant_type' : 'authorization_code',
-                'client_id' : settings.KAKAO_REST_API_KEY,
-                'redirect_uri' : settings.REDIRECT_URI,
-                'code' : code
-            }
-            token_response = requests.post("https://kauth.kakao.com/oauth/token", data=data).json()
-            access_token   = token_response.get('access_token')
-          
+            
+            kakao = KakaoAPI(settings.KAKAO_CONFIG)
+            
+            access_token = kakao.get_access_token(code)
             if not access_token:
                 return JsonResponse({"message" : "INVALID_ACCESS_TOKEN"}, status=401)
 
-            headers = {
-                'Authorization': f'Bearer {access_token}'
-            }
-            user_data_response = requests.post("https://kapi.kakao.com/v2/user/me", headers=headers).json()
-            kakao_id = user_data_response.get('id')
+            user_data = kakao.get_kakao_user_data(access_token)
+            kakao_id = user_data.get('id')
             
             if not kakao_id:
                 return JsonResponse({"message" : "INVALID_KAKAO_ID"}, status=401)
 
-            kakao_account = user_data_response['kakao_account']
+            kakao_account = user_data['kakao_account']
             email         = kakao_account.get('email')
             nickname      = None 
             profile_image = None
@@ -54,6 +67,7 @@ class LoginView(View):
                     "profile_image": profile_image
                 }
             )
+            
             nhouse_token = jwt.encode({"user_id" : user.id}, settings.SECRET_KEY, settings.ALGORITHM)
 
             if not is_created:
@@ -65,6 +79,7 @@ class LoginView(View):
                     user.save()
                 if not user.nickname == nickname:
                     user.nickname = nickname
+                    user.save()
                 return JsonResponse({"message" : "LOGIN_SUCCESS", "access_token" : nhouse_token}, status=200)
 
             return JsonResponse({"message" : "SIGNUP_SUCCESS", "access_token" : nhouse_token}, status=201)  


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- view에서 외부 요청 보내는 기능을 다른 클래스로 분리

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. views.py에 KakaoAPI 클래스 추가
   - KakaoAPI 클래스를 정의하여 두 가지 메서드로 두 가지 요청 보낼 수 있게 수정. 

2. test.py의 테스트 코드 수정

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 캡슐화의 장점과 필요성에 대해 생각해보았습니다.
<br />

## :: 기타 질문 및 특이 사항
- 아래 코멘트에 달아두었습니다.
